### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/boardinghouse/apps.py
+++ b/boardinghouse/apps.py
@@ -76,7 +76,7 @@ def check_db_backend(app_configs=None, **kwargs):
     for name, data in settings.DATABASES.items():
         if data['ENGINE'] not in DB_ENGINES:
             errors.append(Error(
-                'DATABASES[%s][ENGINE] of %s is not a known backend.' % (
+                'DATABASES[{0!s}][ENGINE] of {1!s} is not a known backend.'.format(
                     name, data['ENGINE']
                 ),
                 hint="Try boardinghouse.backends.postgres",

--- a/boardinghouse/base.py
+++ b/boardinghouse/base.py
@@ -28,9 +28,9 @@ class MultiSchemaMixin(object):
         # so we can access it later.
         multi_query = [
             query.replace(
-                'SELECT ', "SELECT '%s' as _schema, " % schema.schema
+                'SELECT ', "SELECT '{0!s}' as _schema, ".format(schema.schema)
             ).replace(
-                'FROM "', 'FROM "%s"."' % schema.schema
+                'FROM "', 'FROM "{0!s}"."'.format(schema.schema)
             ) for schema in schemata
         ]
 

--- a/boardinghouse/contrib/invite/admin.py
+++ b/boardinghouse/contrib/invite/admin.py
@@ -23,7 +23,7 @@ def expiration(obj):
 def redemption_code(obj):
     if obj.redeemed:
         return ''
-    return '<a href="%s" target=_blank>%s</a>' % (
+    return '<a href="{0!s}" target=_blank>{1!s}</a>'.format(
         reverse('invite:view', kwargs={'redemption_code': obj.redemption_code}),
         obj.redemption_code
     )

--- a/boardinghouse/contrib/invite/models.py
+++ b/boardinghouse/contrib/invite/models.py
@@ -64,7 +64,7 @@ class Invitation(SharedSchemaModel):
         app_label = 'invite'
 
     def __unicode__(self):
-        return '[%s] Invitation to %s from %s to join %s' % (
+        return '[{0!s}] Invitation to {1!s} from {2!s} to join {3!s}'.format(
             unicode(self.status), self.email, self.sender, self.schema.name
         )
 

--- a/boardinghouse/models.py
+++ b/boardinghouse/models.py
@@ -189,9 +189,9 @@ def visible_schemata(user):
     signal listeners that automatically invalidate the cache when conditions
     that are detected that would indicate this value has changed.
     """
-    schemata = cache.get('visible-schemata-%s' % user.pk)
+    schemata = cache.get('visible-schemata-{0!s}'.format(user.pk))
     if schemata is None:
         schemata = user.schemata.active()
-        cache.set('visible-schemata-%s' % user.pk, schemata)
+        cache.set('visible-schemata-{0!s}'.format(user.pk), schemata)
 
     return schemata

--- a/boardinghouse/schema.py
+++ b/boardinghouse/schema.py
@@ -37,7 +37,7 @@ def get_schema_model():
     except ValueError:
         raise ImproperlyConfigured("BOARDINGHOUSE_SCHEMA_MODEL must be of the form 'app_label.model_name'")
     except LookupError:
-        raise ImproperlyConfigured("BOARDINGHOUSE_SCHEMA_MODEL refers to model '%s' that has not been installed" % settings.BOARDINGHOUSE_SCHEMA_MODEL)
+        raise ImproperlyConfigured("BOARDINGHOUSE_SCHEMA_MODEL refers to model '{0!s}' that has not been installed".format(settings.BOARDINGHOUSE_SCHEMA_MODEL))
 
 
 def _get_search_path():

--- a/tests/tests/test_user_schemata.py
+++ b/tests/tests/test_user_schemata.py
@@ -14,10 +14,10 @@ class TestUserSchemataCache(TestCase):
         user = User.objects.get(username='a')
         self.assertEqual(0, len(user.visible_schemata))
 
-        self.assertEqual([], list(cache.get('visible-schemata-%s' % user.pk)))
+        self.assertEqual([], list(cache.get('visible-schemata-{0!s}'.format(user.pk))))
 
         user.schemata.add(Schema.objects.get(schema='a'))
-        self.assertEqual(None, cache.get('visible-schemata-%s' % user.pk))
+        self.assertEqual(None, cache.get('visible-schemata-{0!s}'.format(user.pk)))
 
     def test_removing_schema_from_user_clears_cache(self):
         User.objects.create_user(username='a', email='a@example.com', password='a')
@@ -29,7 +29,7 @@ class TestUserSchemataCache(TestCase):
         self.assertEqual(3, len(user.visible_schemata))
 
         user.schemata.remove(Schema.objects.get(schema='a'))
-        self.assertEqual(None, cache.get('visible-schemata-%s' % user.pk))
+        self.assertEqual(None, cache.get('visible-schemata-{0!s}'.format(user.pk)))
 
     def test_adding_users_to_schema_clears_cache(self):
         User.objects.create_user(username='a', email='a@example.com', password='a')
@@ -38,12 +38,12 @@ class TestUserSchemataCache(TestCase):
         user = User.objects.get(username='a')
 
         self.assertEqual(0, len(user.visible_schemata))
-        self.assertEqual([], list(cache.get('visible-schemata-%s' % user.pk)))
+        self.assertEqual([], list(cache.get('visible-schemata-{0!s}'.format(user.pk))))
 
         schema = Schema.objects.get(schema='a')
         schema.users.add(user)
 
-        self.assertEqual(None, cache.get('visible-schemata-%s' % user.pk))
+        self.assertEqual(None, cache.get('visible-schemata-{0!s}'.format(user.pk)))
 
     def test_removing_users_from_schema_clears_cache(self):
         User.objects.create_user(username='a', email='a@example.com', password='a')
@@ -56,7 +56,7 @@ class TestUserSchemataCache(TestCase):
         schema = Schema.objects.get(schema='a')
         schema.users.remove(user)
 
-        self.assertEqual(None, cache.get('visible-schemata-%s' % user.pk))
+        self.assertEqual(None, cache.get('visible-schemata-{0!s}'.format(user.pk)))
 
     def test_saving_schema_clears_cache_for_related_users(self):
         User.objects.create_user(username='a', email='a@example.com', password='a')
@@ -69,7 +69,7 @@ class TestUserSchemataCache(TestCase):
 
         Schema.objects.get(schema='a').save()
 
-        self.assertEqual(None, cache.get('visible-schemata-%s' % user.pk))
+        self.assertEqual(None, cache.get('visible-schemata-{0!s}'.format(user.pk)))
 
     def test_saving_schema_clears_global_active_schemata_cache(self):
         Schema.objects.mass_create('a', 'b', 'c')

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -17,8 +17,8 @@ admin.autodiscover()
 def echo_schema(request):
     data = ""
     if request.GET:
-        data = "\n" + "\n".join("%s=%s" % x for x in request.GET.items())
-    return HttpResponse('%s' % request.session.get('schema') + data)
+        data = "\n" + "\n".join("{0!s}={1!s}".format(*x) for x in request.GET.items())
+    return HttpResponse('{0!s}'.format(request.session.get('schema')) + data)
 
 
 def change_schema_view(request):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:schinckel:django-boardinghouse?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:schinckel:django-boardinghouse?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
